### PR TITLE
Feature/doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ Whenever an action, which previously led to *s<sub>?</sub>*, is being executed a
 The same action might lead from one single state to different states since the states do not capture the whole program behavior.
 This makes the finite automaton nondeterministic.
 
-The NFA is based on the UI model from ["Search-Based System Testing: High Coverage, No False Alarms"](http://www.specmate.org/papers/2012-07-Search-basedSystemTesting-HighCoverageNoFalseAlarms.pdf) (section "4.5 UI Model"). Originally, it has been used together with a genetic algorithm for search-based system testing, where it served two purposes:
+The NFA is based on the UI model from ["Search-Based System Testing: High Coverage, No False Alarms"](http://www.specmate.org/papers/2012-07-Search-basedSystemTesting-HighCoverageNoFalseAlarms.pdf) (section "4.5 UI Model"). Originally, it has been used together with a genetic algorithm for search-based system testing, where it served three purposes:
 
 1. Population initialization: to give precedence to unexplored actions.
-2. Mutation: to repair test cases.
+2. Mutation: to insert unexplored actions.
+3. Mutation: to repair test cases which became invalid by the mutation.
 
 ## Concurrency
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The actions executed by the user on GUI elements are represented by transitions.
 If an action has not been executed yet from a state, it leads to the so-called unknown state *s<sub>?</sub>*.
 The unknown state is a special state from which all actions could be executed.
 Whenever an action, which previously led to *s<sub>?</sub>*, is being executed and then leads to a newly discovered state, the NFA has to be updated.
+The same action might lead from one single state to different states since the states do not capture the whole program behavior.
+This makes the finite automaton nondeterministic.
 
 The NFA is based on the UI model from ["Search-Based System Testing: High Coverage, No False Alarms"](http://www.specmate.org/papers/2012-07-Search-basedSystemTesting-HighCoverageNoFalseAlarms.pdf) (section "4.5 UI Model"). Originally, it has been used together with a genetic algorithm for search-based system testing, where it served two purposes:
 


### PR DESCRIPTION
In the legacy code look at `ActionStateSequenceOld.insertRandomActionUnsafe` which was used for the insert mutation of a test case. It added a new action from one of the states. `AbstractState.getNewRandomAction` was never implemented but the paper states:

> Insert operator: With decreasing probability (1.0, 0.5, 0.25)
> a new action is inserted into the sequence. Each insertion
> happens at a random position of the interaction sequence.
> A random unexplored action available in that state is chosen
> and inserted into the interaction sequence just after that state,
> if available, else we fallback to a random action.

To get a random **unexplored** action, we have to know which actions have been explored?
This information is only available from the SUT model?