### PR TITLE
Feature/unexplored actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ val currentState = stateMachine.createState(currentSutState, 1)
 val action = new NavigateToAction("http://google.com")
 val nextSutState = new SutState(nextDescriptors)
 val nextState = stateMachine.createState(nextSutState, 1)
-stateMachine.executeAction(currentState, action, nextState)
+stateMachine.executeAction(currentState, action, nextState, true)
 
 GuiStateMachineSerializer.javaObjectStream(stateMachine).save("mystatemachine.ser")
 GuiStateMachineSerializer.gml(stateMachine).save("mystatemachine.gml")

--- a/README.md
+++ b/README.md
@@ -13,14 +13,20 @@ import de.retest.guistatemachine.api.GuiStateMachineApi
 import de.retest.guistatemachine.api.GuiStateMachineSerializer
 import de.retest.recheck.ui.descriptors.SutState
 import de.retest.surili.commons.actions.NavigateToAction
+import de.retest.surili.commons.actions.ActionType
+
+val action = new NavigateToAction("http://google.com")
+val unexploredActionTypes = Set(ActionType.fromAction(action))
 
 val stateMachine = GuiStateMachineApi().createStateMachine("test")
+
 val currentSutState = new SutState(currentDescriptors)
-val currentState = stateMachine.createState(currentSutState, 1)
-val action = new NavigateToAction("http://google.com")
+val currentState = stateMachine.createState(currentSutState, unexploredActionTypes)
+
 val nextSutState = new SutState(nextDescriptors)
-val nextState = stateMachine.createState(nextSutState, 1)
-stateMachine.executeAction(currentState, action, nextState, true)
+val nextState = stateMachine.createState(nextSutState, unexploredActionTypes)
+
+stateMachine.executeAction(currentState, action, nextState)
 
 GuiStateMachineSerializer.javaObjectStream(stateMachine).save("mystatemachine.ser")
 GuiStateMachineSerializer.gml(stateMachine).save("mystatemachine.gml")

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ import de.retest.recheck.ui.descriptors.SutState
 import de.retest.surili.commons.actions.NavigateToAction
 
 val stateMachine = GuiStateMachineApi().createStateMachine("test")
-val currentState = new SutState(currentDescriptors)
+val currentSutState = new SutState(currentDescriptors)
+val currentState = stateMachine.createState(currentSutState, 1)
 val action = new NavigateToAction("http://google.com")
-val nextState = new SutState(nextDescriptors)
+val nextSutState = new SutState(nextDescriptors)
+val nextState = stateMachine.createState(nextSutState, 1)
 stateMachine.executeAction(currentState, action, nextState)
 
 GuiStateMachineSerializer.javaObjectStream(stateMachine).save("mystatemachine.ser")

--- a/src/main/scala/de/retest/guistatemachine/api/GuiStateMachine.scala
+++ b/src/main/scala/de/retest/guistatemachine/api/GuiStateMachine.scala
@@ -1,7 +1,7 @@
 package de.retest.guistatemachine.api
 
 import de.retest.recheck.ui.descriptors.SutState
-import de.retest.surili.commons.actions.Action
+import de.retest.surili.commons.actions.{Action, ActionType}
 
 /**
   * API to create a NFA which represents the current state machine of an automatic GUI test generation with the help of a genetic algorithm.
@@ -15,16 +15,15 @@ trait GuiStateMachine {
 
   /**
     * Creates a new state in the state machine based on a SUT state.
+    *
     * @param sutStateIdentifier The abstract representation of a SUT state which should uniquely identify the state.
-    * @param neverExploredActionTypesCounter The initial number of unexplored action types. This number is decremented with each unexplored action which is added as a new transition.
+    * @param unexploredActionTypes The initially unexplored action types. This set is modified whenever an action is executed which has an unexplored action type.
     * @return The newly created state.
-    * @throws RuntimeException If the state does already exist.
-    * @group possibleactions
     */
-  def createState(sutStateIdentifier: SutStateIdentifier, neverExploredActionTypesCounter: Int): State
+  def createState(sutStateIdentifier: SutStateIdentifier, unexploredActionTypes: Set[ActionType]): State
 
-  def createState(sutState: SutState, neverExploredActionTypesCounter: Int): State =
-    createState(new SutStateIdentifier(sutState), neverExploredActionTypesCounter)
+  def createState(sutState: SutState, unexploredActionTypes: Set[ActionType]): State =
+    createState(new SutStateIdentifier(sutState), unexploredActionTypes)
 
   def getState(sutStateIdentifier: SutStateIdentifier): Option[State]
 
@@ -42,11 +41,12 @@ trait GuiStateMachine {
     * @param from The state the action is executed from
     * @param a The action which is executed by the user.
     * @param to The state which the execution leads to.
+    * @param actionType The corresponding action type of a.
     * @return The number of times the action has been executed.
     */
-  def executeAction(from: State, a: ActionIdentifier, to: State, isUnexploredActionType: Boolean): Int = from.addTransition(a, to, isUnexploredActionType)
-  def executeAction(from: State, a: Action, to: State, isUnexploredActionType: Boolean): Int =
-    executeAction(from, new ActionIdentifier(a), to, isUnexploredActionType)
+  def executeAction(from: State, a: ActionIdentifier, to: State, actionType: ActionType): Int = from.addTransition(a, to, actionType)
+  def executeAction(from: State, a: Action, to: State): Int =
+    executeAction(from, new ActionIdentifier(a), to, ActionType.fromAction(a))
 
   def getAllStates: Map[SutStateIdentifier, State]
 

--- a/src/main/scala/de/retest/guistatemachine/api/GuiStateMachine.scala
+++ b/src/main/scala/de/retest/guistatemachine/api/GuiStateMachine.scala
@@ -44,8 +44,9 @@ trait GuiStateMachine {
     * @param to The state which the execution leads to.
     * @return The number of times the action has been executed.
     */
-  def executeAction(from: State, a: ActionIdentifier, to: State): Int = from.addTransition(a, to)
-  def executeAction(from: State, a: Action, to: State): Int = executeAction(from, new ActionIdentifier(a), to)
+  def executeAction(from: State, a: ActionIdentifier, to: State, isUnexploredActionType: Boolean): Int = from.addTransition(a, to, isUnexploredActionType)
+  def executeAction(from: State, a: Action, to: State, isUnexploredActionType: Boolean): Int =
+    executeAction(from, new ActionIdentifier(a), to, isUnexploredActionType)
 
   def getAllStates: Map[SutStateIdentifier, State]
 

--- a/src/main/scala/de/retest/guistatemachine/api/GuiStateMachine.scala
+++ b/src/main/scala/de/retest/guistatemachine/api/GuiStateMachine.scala
@@ -13,7 +13,20 @@ import de.retest.surili.commons.actions.Action
   */
 trait GuiStateMachine {
 
-  def getState(sutStateIdentifier: SutStateIdentifier): State
+  /**
+    * Creates a new state in the state machine based on a SUT state.
+    * @param sutStateIdentifier The abstract representation of a SUT state which should uniquely identify the state.
+    * @param neverExploredActionTypesCounter The initial number of unexplored action types. This number is decremented with each unexplored action which is added as a new transition.
+    * @return The newly created state.
+    * @throws RuntimeException If the state does already exist.
+    * @group possibleactions
+    */
+  def createState(sutStateIdentifier: SutStateIdentifier, neverExploredActionTypesCounter: Int): State
+
+  def createState(sutState: SutState, neverExploredActionTypesCounter: Int): State =
+    createState(new SutStateIdentifier(sutState), neverExploredActionTypesCounter)
+
+  def getState(sutStateIdentifier: SutStateIdentifier): Option[State]
 
   /**
     * Gets a state identified by the corresponding SUT state.
@@ -21,7 +34,7 @@ trait GuiStateMachine {
     * @param sutState The SUT state which identifies the state.
     * @return The state identified by the descriptors. If there has not been any state yet, it will be added.
     */
-  def getState(sutState: SutState): State = getState(new SutStateIdentifier(sutState))
+  def getState(sutState: SutState): Option[State] = getState(new SutStateIdentifier(sutState))
 
   /**
     * Executes an action from a state leading to the current state described by descriptors.
@@ -33,8 +46,6 @@ trait GuiStateMachine {
     */
   def executeAction(from: State, a: ActionIdentifier, to: State): Int = from.addTransition(a, to)
   def executeAction(from: State, a: Action, to: State): Int = executeAction(from, new ActionIdentifier(a), to)
-  def executeAction(fromSutState: SutState, a: Action, toSutState: SutState): Int =
-    executeAction(getState(fromSutState), a, getState(toSutState))
 
   def getAllStates: Map[SutStateIdentifier, State]
 

--- a/src/main/scala/de/retest/guistatemachine/api/State.scala
+++ b/src/main/scala/de/retest/guistatemachine/api/State.scala
@@ -48,7 +48,7 @@ trait State {
 
   override def hashCode(): Int = this.getSutStateIdentifier.hashCode()
 
-  override def toString: String = s"State[sutStateIdentifier=$getSutStateIdentifier]"
+  override def toString: String = s"State[sutStateIdentifier=$getSutStateIdentifier,neverExploredActionTypesCounter=$getNeverExploredActionTypesCounter]"
 
   /**
     * Adds a new transition to the state which is only allowed by calling the methods of [[GuiStateMachine]].

--- a/src/main/scala/de/retest/guistatemachine/api/State.scala
+++ b/src/main/scala/de/retest/guistatemachine/api/State.scala
@@ -55,7 +55,8 @@ trait State {
     *
     * @param a The action which represents the transition's consumed symbol.
     * @param to The state which the transition leads t o.
+    * @param isUnexploredActionType If this flag is true, the never explored action types counter is decreased.
     * @return The number of times the action has been executed from this state. The target state does not matter for this number.
     */
-  private[api] def addTransition(a: ActionIdentifier, to: State): Int
+  private[api] def addTransition(a: ActionIdentifier, to: State, isUnexploredActionType: Boolean): Int
 }

--- a/src/main/scala/de/retest/guistatemachine/api/State.scala
+++ b/src/main/scala/de/retest/guistatemachine/api/State.scala
@@ -27,16 +27,10 @@ trait State {
     * @groupname possibleactions Possible Actions
     * The set of possible actions has to be restricted for certain action types like ChangeValueAction. The set should always be the same for the same elements per state. It can be used for exploration strategies.
     *
-    * @param possibleActions The possible actions of the state.
+    * @return The number of unexplored action types in this state.
     * @group possibleactions
     */
-  def setPossibleActions(possibleActions: Set[ActionIdentifier])
-
-  /**
-    * @return The possible actions of the state.
-    * @group possibleactions
-    */
-  def getPossibleActions: Set[ActionIdentifier]
+  def getNeverExploredActionTypesCounter: Int
 
   /**
     * Overriding this method is required to allow the usage of a set of states.

--- a/src/main/scala/de/retest/guistatemachine/api/State.scala
+++ b/src/main/scala/de/retest/guistatemachine/api/State.scala
@@ -1,5 +1,7 @@
 package de.retest.guistatemachine.api
 
+import de.retest.surili.commons.actions.ActionType
+
 /**
   * A state should be identified by its corresponding SutState.
   * It consists of actions which have not been explored yet and transitions to states which build up the state machine.
@@ -24,13 +26,11 @@ trait State {
   def getIncomingActionTransitions: Map[ActionIdentifier, ActionTransitions]
 
   /**
-    * @groupname possibleactions Possible Actions
     * The set of possible actions has to be restricted for certain action types like ChangeValueAction. The set should always be the same for the same elements per state. It can be used for exploration strategies.
     *
-    * @return The number of unexplored action types in this state.
-    * @group possibleactions
+    * @return The set of unexplored action types in this state.
     */
-  def getNeverExploredActionTypesCounter: Int
+  def getUnexploredActionTypes: Set[ActionType]
 
   /**
     * Overriding this method is required to allow the usage of a set of states.
@@ -48,15 +48,15 @@ trait State {
 
   override def hashCode(): Int = this.getSutStateIdentifier.hashCode()
 
-  override def toString: String = s"State[sutStateIdentifier=$getSutStateIdentifier,neverExploredActionTypesCounter=$getNeverExploredActionTypesCounter]"
+  override def toString: String = s"State[sutStateIdentifier=$getSutStateIdentifier,unexploredActionTypes=$getUnexploredActionTypes]"
 
   /**
     * Adds a new transition to the state which is only allowed by calling the methods of [[GuiStateMachine]].
     *
     * @param a The action which represents the transition's consumed symbol.
-    * @param to The state which the transition leads t o.
-    * @param isUnexploredActionType If this flag is true, the never explored action types counter is decreased.
+    * @param to The state which the transition leads to.
+    * @param actionType The corresponding action type of a.
     * @return The number of times the action has been executed from this state. The target state does not matter for this number.
     */
-  private[api] def addTransition(a: ActionIdentifier, to: State, isUnexploredActionType: Boolean): Int
+  private[api] def addTransition(a: ActionIdentifier, to: State, actionType: ActionType): Int
 }

--- a/src/main/scala/de/retest/guistatemachine/api/State.scala
+++ b/src/main/scala/de/retest/guistatemachine/api/State.scala
@@ -24,6 +24,21 @@ trait State {
   def getIncomingActionTransitions: Map[ActionIdentifier, ActionTransitions]
 
   /**
+    * @groupname possibleactions Possible Actions
+    * The set of possible actions has to be restricted for certain action types like ChangeValueAction. The set should always be the same for the same elements per state. It can be used for exploration strategies.
+    *
+    * @param possibleActions The possible actions of the state.
+    * @group possibleactions
+    */
+  def setPossibleActions(possibleActions: Set[ActionIdentifier])
+
+  /**
+    * @return The possible actions of the state.
+    * @group possibleactions
+    */
+  def getPossibleActions: Set[ActionIdentifier]
+
+  /**
     * Overriding this method is required to allow the usage of a set of states.
     * Comparing the descriptors should check for the equality of all root elements which compares the identifying attributes and the contained components
     * for each root element.

--- a/src/main/scala/de/retest/guistatemachine/api/impl/GuiStateMachineImpl.scala
+++ b/src/main/scala/de/retest/guistatemachine/api/impl/GuiStateMachineImpl.scala
@@ -2,6 +2,7 @@ package de.retest.guistatemachine.api.impl
 
 import com.typesafe.scalalogging.Logger
 import de.retest.guistatemachine.api.{GuiStateMachine, State, SutStateIdentifier}
+import de.retest.surili.commons.actions.ActionType
 
 import scala.collection.mutable.HashMap
 
@@ -13,15 +14,17 @@ class GuiStateMachineImpl extends GuiStateMachine with Serializable {
   @transient private val logger = Logger[GuiStateMachineImpl]
   private var states = HashMap[SutStateIdentifier, State]()
 
-  override def createState(sutStateIdentifier: SutStateIdentifier, neverExploredActionTypesCounter: Int): State =
+  override def createState(sutStateIdentifier: SutStateIdentifier, unexploredActionTypes: Set[ActionType]): State =
     this.synchronized {
-      if (states.contains(sutStateIdentifier)) {
-        throw new RuntimeException(s"State from SUT state $sutStateIdentifier does already exist.")
-      } else {
-        logger.info(s"Create new state from SUT state $sutStateIdentifier")
-        val s = StateImpl(sutStateIdentifier, neverExploredActionTypesCounter)
-        states += (sutStateIdentifier -> s)
-        s
+      states.get(sutStateIdentifier) match {
+        case Some(s) =>
+          logger.warn(s"State from SUT state $sutStateIdentifier does already exist.")
+          s
+        case None =>
+          logger.info(s"Create new state from SUT state $sutStateIdentifier")
+          val s = StateImpl(sutStateIdentifier, unexploredActionTypes)
+          states += (sutStateIdentifier -> s)
+          s
       }
     }
 

--- a/src/main/scala/de/retest/guistatemachine/api/impl/GuiStateMachineImpl.scala
+++ b/src/main/scala/de/retest/guistatemachine/api/impl/GuiStateMachineImpl.scala
@@ -3,7 +3,7 @@ package de.retest.guistatemachine.api.impl
 import com.typesafe.scalalogging.Logger
 import de.retest.guistatemachine.api.{GuiStateMachine, State, SutStateIdentifier}
 
-import scala.collection.concurrent.TrieMap
+import scala.collection.mutable.HashMap
 
 /**
   * Thread-safe implementation of a GUI state machine.
@@ -11,25 +11,31 @@ import scala.collection.concurrent.TrieMap
 @SerialVersionUID(1L)
 class GuiStateMachineImpl extends GuiStateMachine with Serializable {
   @transient private val logger = Logger[GuiStateMachineImpl]
-  private var states = TrieMap[SutStateIdentifier, State]()
+  private var states = HashMap[SutStateIdentifier, State]()
 
-  override def getState(sutState: SutStateIdentifier): State =
-    if (states.contains(sutState)) {
-      states(sutState)
-    } else {
-      logger.info(s"Create new state from SUT state $sutState")
-      val s = StateImpl(sutState)
-      states += (sutState -> s)
-      s
+  override def createState(sutStateIdentifier: SutStateIdentifier, neverExploredActionTypesCounter: Int): State =
+    this.synchronized {
+      if (states.contains(sutStateIdentifier)) {
+        throw new RuntimeException(s"State from SUT state $sutStateIdentifier does already exist.")
+      } else {
+        logger.info(s"Create new state from SUT state $sutStateIdentifier")
+        val s = StateImpl(sutStateIdentifier, neverExploredActionTypesCounter)
+        states += (sutStateIdentifier -> s)
+        s
+      }
     }
+
+  override def getState(sutStateIdentifier: SutStateIdentifier): Option[State] = this.synchronized {
+    states.get(sutStateIdentifier)
+  }
 
   override def getAllStates: Map[SutStateIdentifier, State] = states.toMap
 
-  override def clear(): Unit = {
-    states = TrieMap[SutStateIdentifier, State]()
+  override def clear(): Unit = this.synchronized {
+    states.clear()
   }
 
-  override def assignFrom(other: GuiStateMachine): Unit = {
+  override def assignFrom(other: GuiStateMachine): Unit = this.synchronized {
     clear()
     val otherStateMachine = other.asInstanceOf[GuiStateMachineImpl]
     states = otherStateMachine.states

--- a/src/main/scala/de/retest/guistatemachine/api/impl/StateImpl.scala
+++ b/src/main/scala/de/retest/guistatemachine/api/impl/StateImpl.scala
@@ -1,11 +1,12 @@
 package de.retest.guistatemachine.api.impl
 
 import de.retest.guistatemachine.api.{ActionIdentifier, ActionTransitions, State, SutStateIdentifier}
+import de.retest.surili.commons.actions.ActionType
 
 import scala.collection.immutable.HashMap
 
 @SerialVersionUID(1L)
-case class StateImpl(sutState: SutStateIdentifier, var neverExploredActionTypesCounter: Int) extends State with Serializable {
+case class StateImpl(sutState: SutStateIdentifier, var unexploredActionTypes: Set[ActionType]) extends State with Serializable {
 
   /**
     * Currently, there is no MultiMap trait for immutable maps in the Scala standard library.
@@ -25,13 +26,11 @@ case class StateImpl(sutState: SutStateIdentifier, var neverExploredActionTypesC
   override def getIncomingActionTransitions: Map[ActionIdentifier, ActionTransitions] = this.synchronized {
     incomingActionTransitions
   }
-  override def getNeverExploredActionTypesCounter: Int = this.synchronized { neverExploredActionTypesCounter }
+  override def getUnexploredActionTypes: Set[ActionType] = this.synchronized { unexploredActionTypes }
 
-  private[api] override def addTransition(a: ActionIdentifier, to: State, isUnexploredActionType: Boolean): Int = {
+  private[api] override def addTransition(a: ActionIdentifier, to: State, actionType: ActionType): Int = {
     val executionCounter = this.synchronized {
-      if (isUnexploredActionType) {
-        neverExploredActionTypesCounter = neverExploredActionTypesCounter - 1
-      }
+      unexploredActionTypes = unexploredActionTypes - actionType
 
       outgoingActionTransitions.get(a) match {
         case Some(oldTransitions) =>

--- a/src/main/scala/de/retest/guistatemachine/api/impl/StateImpl.scala
+++ b/src/main/scala/de/retest/guistatemachine/api/impl/StateImpl.scala
@@ -2,7 +2,7 @@ package de.retest.guistatemachine.api.impl
 
 import de.retest.guistatemachine.api.{ActionIdentifier, ActionTransitions, State, SutStateIdentifier}
 
-import scala.collection.immutable.HashMap
+import scala.collection.immutable.{HashMap, HashSet}
 
 @SerialVersionUID(1L)
 case class StateImpl(sutState: SutStateIdentifier) extends State with Serializable {
@@ -18,9 +18,19 @@ case class StateImpl(sutState: SutStateIdentifier) extends State with Serializab
     */
   private var incomingActionTransitions = HashMap[ActionIdentifier, ActionTransitions]()
 
+  private var possibleActions: Set[ActionIdentifier] = HashSet[ActionIdentifier]()
+
   override def getSutStateIdentifier: SutStateIdentifier = this.synchronized { sutState }
-  override def getOutgoingActionTransitions: Map[ActionIdentifier, ActionTransitions] = this.synchronized { outgoingActionTransitions }
-  override def getIncomingActionTransitions: Map[ActionIdentifier, ActionTransitions] = this.synchronized { incomingActionTransitions }
+  override def getOutgoingActionTransitions: Map[ActionIdentifier, ActionTransitions] = this.synchronized {
+    outgoingActionTransitions
+  }
+  override def getIncomingActionTransitions: Map[ActionIdentifier, ActionTransitions] = this.synchronized {
+    incomingActionTransitions
+  }
+  override def setPossibleActions(possibleActions: Set[ActionIdentifier]): Unit = this.synchronized {
+    this.possibleActions = possibleActions
+  }
+  override def getPossibleActions: Set[ActionIdentifier] = this.synchronized { possibleActions }
 
   private[api] override def addTransition(a: ActionIdentifier, to: State): Int = {
     val executionCounter = this.synchronized {

--- a/src/main/scala/de/retest/guistatemachine/api/impl/serialization/GraphicsProvider.scala
+++ b/src/main/scala/de/retest/guistatemachine/api/impl/serialization/GraphicsProvider.scala
@@ -7,7 +7,11 @@ import de.retest.guistatemachine.api.SutStateIdentifier
 
 class GraphicsProvider extends YedGmlGraphicsProvider[SutStateIdentifier, GraphActionEdge, AnyRef] {
   override def getVertexGraphics(vertex: SutStateIdentifier): NodeGraphicDefinition =
-    new NodeGraphicDefinition.Builder().setFill(Color.LIGHT_GRAY).setLineColor(Color.black).setFontStyle(GraphicDefinition.FontStyle.ITALIC).build
+    new NodeGraphicDefinition.Builder()
+      .setFill(Color.LIGHT_GRAY)
+      .setLineColor(Color.black)
+      .setFontStyle(GraphicDefinition.FontStyle.ITALIC)
+      .build
   override def getEdgeGraphics(edge: GraphActionEdge, edgeSource: SutStateIdentifier, edgeTarget: SutStateIdentifier): EdgeGraphicDefinition =
     new EdgeGraphicDefinition.Builder()
       .setTargetArrow(EdgeGraphicDefinition.ArrowType.SHORT_ARROW)

--- a/src/main/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachinGMLSerializer.scala
+++ b/src/main/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachinGMLSerializer.scala
@@ -47,7 +47,8 @@ class GuiStateMachinGMLSerializer(guiStateMachine: GuiStateMachine) extends GuiS
 
     allStatesSorted.foreach { x =>
       val fromVertex = x._1
-      val allOutgoingActionTransitionsSorted = x._2.getOutgoingActionTransitions.toSeq.sortWith(hashCodeComparisonOfTuples)
+      val allOutgoingActionTransitionsSorted =
+        x._2.getOutgoingActionTransitions.toSeq.sortWith(hashCodeComparisonOfTuples)
 
       allOutgoingActionTransitionsSorted foreach { transition =>
         val actionTransitions = transition._2

--- a/src/test/scala/de/retest/guistatemachine/api/AbstractApiSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/AbstractApiSpec.scala
@@ -4,9 +4,20 @@ import java.util.Arrays
 
 import de.retest.recheck.ui.descriptors._
 import de.retest.recheck.ui.image.Screenshot
+import de.retest.surili.commons.actions.{ActionType, NavigateToAction}
 import org.scalatest.{Matchers, WordSpec}
 
 abstract trait AbstractApiSpec extends WordSpec with Matchers {
+  protected val rootElementA = getRootElement("a", 0)
+  protected val rootElementB = getRootElement("b", 0)
+  protected val rootElementC = getRootElement("c", 0)
+  protected val action0 = new NavigateToAction("http://google.com")
+  protected val action0Identifier = new ActionIdentifier(action0)
+  protected val actionType0 = ActionType.fromAction(action0)
+  protected val action1 = new NavigateToAction("http://wikipedia.org")
+  protected val action1Identifier = new ActionIdentifier(action1)
+  protected val actionType1 = ActionType.fromAction(action1)
+  protected val unexploredActionTypes = Set(actionType0, actionType1)
 
   def createSutState(rootElements: RootElement*): SutState = new SutState(Arrays.asList(rootElements: _*))
 

--- a/src/test/scala/de/retest/guistatemachine/api/HashIdentifierSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/HashIdentifierSpec.scala
@@ -17,11 +17,16 @@ class HashIdentifierSpec extends AbstractApiSpec {
     "not equal" in {
       action0Identifier.equals(action1Identifier) shouldEqual false
       action0Identifier.hashCode() should not equal action1Identifier.hashCode()
+      action0Identifier.equals(10) shouldEqual false
     }
 
     "equal" in {
       action0Identifier.equals(action0Identifier) shouldEqual true
       action0Identifier.hashCode() shouldEqual action0Identifier.hashCode()
+    }
+
+    "be converted into a string" in {
+      action0Identifier.toString shouldEqual "HashIdentifier[hash=fd00ea22cb50efd96c3ff59d8900685d0d64f2cee1e77873133e7e186afd2e7f]"
     }
   }
 }

--- a/src/test/scala/de/retest/guistatemachine/api/HashIdentifierSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/HashIdentifierSpec.scala
@@ -1,12 +1,6 @@
 package de.retest.guistatemachine.api
 
-import de.retest.surili.commons.actions.NavigateToAction
-
 class HashIdentifierSpec extends AbstractApiSpec {
-  private val action0 = new NavigateToAction("http://google.com")
-  private val action0Identifier = new HashIdentifier(action0)
-  private val action1 = new NavigateToAction("http://wikipedia.org")
-  private val action1Identifier = new HashIdentifier(action1)
 
   "HashIdentifier" should {
     "generate SHA hashes" in {
@@ -26,7 +20,7 @@ class HashIdentifierSpec extends AbstractApiSpec {
     }
 
     "be converted into a string" in {
-      action0Identifier.toString shouldEqual "HashIdentifier[hash=fd00ea22cb50efd96c3ff59d8900685d0d64f2cee1e77873133e7e186afd2e7f]"
+      action0Identifier.toString shouldEqual "ActionIdentifier[action=NavigateToAction(url=http://google.com), hash=fd00ea22cb50efd96c3ff59d8900685d0d64f2cee1e77873133e7e186afd2e7f]"
     }
   }
 }

--- a/src/test/scala/de/retest/guistatemachine/api/impl/GuiStateMachineImplSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/impl/GuiStateMachineImplSpec.scala
@@ -28,69 +28,78 @@ class GuiStateMachineImplSpec extends AbstractApiSpec with BeforeAndAfterEach {
       differentState.equals(s0) shouldBe false
       differentState.hashCode() should not equal s0.hashCode()
       sut.getAllStates.size shouldEqual 0
-      sut.getState(s0)
+      sut.createState(s0, 0)
       sut.getAllStates.size shouldEqual 1
-      sut.getState(s0Equal)
+      the[RuntimeException] thrownBy sut.createState(s0Equal, 0)
       sut.getAllStates.size shouldEqual 1
-      sut.getState(differentState)
+      sut.createState(differentState, 0)
       sut.getAllStates.size shouldEqual 2
     }
 
     "add two transitions to two new states for the same action and two transitions for the same action to another state" in {
       val initialSutState = createSutState(rootElementA, rootElementB, rootElementC)
-      val initial = sut.getState(initialSutState)
+      val initial = sut.createState(initialSutState, 2)
+      initial.getNeverExploredActionTypesCounter shouldEqual 2
 
       // execute action0 for the first time
       val s0SutState = createSutState(rootElementA)
-      val s0 = sut.getState(s0SutState)
-      sut.executeAction(initialSutState, action0, s0SutState) shouldEqual 1
+      val s0 = sut.createState(s0SutState, 2)
+      sut.executeAction(initial, action0, s0) shouldEqual 1
       initial.getOutgoingActionTransitions.size shouldEqual 1
       initial.getOutgoingActionTransitions(action0Identifier).states.size shouldEqual 1
       initial.getOutgoingActionTransitions(action0Identifier).executionCounter shouldEqual 1
       initial.getIncomingActionTransitions.size shouldEqual 0
+      initial.getNeverExploredActionTypesCounter shouldEqual 1
       s0.getOutgoingActionTransitions.size shouldEqual 0
       s0.getIncomingActionTransitions.size shouldEqual 1
       s0.getIncomingActionTransitions(action0Identifier).states.size shouldEqual 1
       s0.getIncomingActionTransitions(action0Identifier).executionCounter shouldEqual 1
+      s0.getNeverExploredActionTypesCounter shouldEqual 2
 
       // execute action0 for the second time
       val s1SutState = createSutState(rootElementB)
-      val s1 = sut.getState(s1SutState)
-      sut.executeAction(initialSutState, action0, s1SutState) shouldEqual 2
+      val s1 = sut.createState(s1SutState, 2)
+      sut.executeAction(initial, action0, s1) shouldEqual 2
       initial.getOutgoingActionTransitions.size shouldEqual 1
       initial.getOutgoingActionTransitions(action0Identifier).states.size shouldEqual 2
       initial.getOutgoingActionTransitions(action0Identifier).executionCounter shouldEqual 2
       initial.getIncomingActionTransitions.size shouldEqual 0
+      initial.getNeverExploredActionTypesCounter shouldEqual 1
       s1.getOutgoingActionTransitions.size shouldEqual 0
       s1.getIncomingActionTransitions.size shouldEqual 1
       s1.getIncomingActionTransitions(action0Identifier).states.size shouldEqual 1
       s1.getIncomingActionTransitions(action0Identifier).executionCounter shouldEqual 1
+      s1.getNeverExploredActionTypesCounter shouldEqual 2
 
       // execute action1 for the first time
       val s2SutState = createSutState(rootElementC)
-      val s2 = sut.getState(s2SutState)
-      sut.executeAction(initialSutState, action1, s2SutState) shouldEqual 1
+      val s2 = sut.createState(s2SutState, 2)
+      sut.executeAction(initial, action1, s2) shouldEqual 1
       initial.getOutgoingActionTransitions.size shouldEqual 2
       initial.getOutgoingActionTransitions(action1Identifier).states.size shouldEqual 1
       initial.getOutgoingActionTransitions(action1Identifier).executionCounter shouldEqual 1
       initial.getIncomingActionTransitions.size shouldEqual 0
+      initial.getNeverExploredActionTypesCounter shouldEqual 0
       s2.getOutgoingActionTransitions.size shouldEqual 0
       s2.getIncomingActionTransitions.size shouldEqual 1
       s2.getIncomingActionTransitions(action1Identifier).states.size shouldEqual 1
       s2.getIncomingActionTransitions(action1Identifier).executionCounter shouldEqual 1
+      s2.getNeverExploredActionTypesCounter shouldEqual 2
 
       // execute action1 for the second time but from s1SutState to create one incoming action from two different states
-      sut.executeAction(s1SutState, action1, s2SutState) shouldEqual 1
+      sut.executeAction(s1, action1, s2) shouldEqual 1
       s1.getOutgoingActionTransitions.size shouldEqual 1
       s1.getOutgoingActionTransitions(action1Identifier).states.size shouldEqual 1
       s1.getOutgoingActionTransitions(action1Identifier).executionCounter shouldEqual 1
       s1.getIncomingActionTransitions.size shouldEqual 1
       s1.getIncomingActionTransitions(action0Identifier).states.size shouldEqual 1
       s1.getIncomingActionTransitions(action0Identifier).executionCounter shouldEqual 1
+      s1.getNeverExploredActionTypesCounter shouldEqual 1
       s2.getOutgoingActionTransitions.size shouldEqual 0
       s2.getIncomingActionTransitions.size shouldEqual 1
       s2.getIncomingActionTransitions(action1Identifier).states shouldEqual Set(initial, s1)
       s2.getIncomingActionTransitions(action1Identifier).executionCounter shouldEqual 2
+      s2.getNeverExploredActionTypesCounter shouldEqual 2
     }
 
     "store a state for the second access" in {

--- a/src/test/scala/de/retest/guistatemachine/api/impl/GuiStateMachineImplSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/impl/GuiStateMachineImplSpec.scala
@@ -59,7 +59,7 @@ class GuiStateMachineImplSpec extends AbstractApiSpec with BeforeAndAfterEach {
       // execute action0 for the second time
       val s1SutState = createSutState(rootElementB)
       val s1 = sut.createState(s1SutState, 2)
-      sut.executeAction(initial, action0, s1, true) shouldEqual 2
+      sut.executeAction(initial, action0, s1, false) shouldEqual 2
       initial.getOutgoingActionTransitions.size shouldEqual 1
       initial.getOutgoingActionTransitions(action0Identifier).states.size shouldEqual 2
       initial.getOutgoingActionTransitions(action0Identifier).executionCounter shouldEqual 2

--- a/src/test/scala/de/retest/guistatemachine/api/impl/GuiStateMachineImplSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/impl/GuiStateMachineImplSpec.scala
@@ -44,7 +44,7 @@ class GuiStateMachineImplSpec extends AbstractApiSpec with BeforeAndAfterEach {
       // execute action0 for the first time
       val s0SutState = createSutState(rootElementA)
       val s0 = sut.createState(s0SutState, 2)
-      sut.executeAction(initial, action0, s0) shouldEqual 1
+      sut.executeAction(initial, action0, s0, true) shouldEqual 1
       initial.getOutgoingActionTransitions.size shouldEqual 1
       initial.getOutgoingActionTransitions(action0Identifier).states.size shouldEqual 1
       initial.getOutgoingActionTransitions(action0Identifier).executionCounter shouldEqual 1
@@ -59,7 +59,7 @@ class GuiStateMachineImplSpec extends AbstractApiSpec with BeforeAndAfterEach {
       // execute action0 for the second time
       val s1SutState = createSutState(rootElementB)
       val s1 = sut.createState(s1SutState, 2)
-      sut.executeAction(initial, action0, s1) shouldEqual 2
+      sut.executeAction(initial, action0, s1, true) shouldEqual 2
       initial.getOutgoingActionTransitions.size shouldEqual 1
       initial.getOutgoingActionTransitions(action0Identifier).states.size shouldEqual 2
       initial.getOutgoingActionTransitions(action0Identifier).executionCounter shouldEqual 2
@@ -74,7 +74,7 @@ class GuiStateMachineImplSpec extends AbstractApiSpec with BeforeAndAfterEach {
       // execute action1 for the first time
       val s2SutState = createSutState(rootElementC)
       val s2 = sut.createState(s2SutState, 2)
-      sut.executeAction(initial, action1, s2) shouldEqual 1
+      sut.executeAction(initial, action1, s2, true) shouldEqual 1
       initial.getOutgoingActionTransitions.size shouldEqual 2
       initial.getOutgoingActionTransitions(action1Identifier).states.size shouldEqual 1
       initial.getOutgoingActionTransitions(action1Identifier).executionCounter shouldEqual 1
@@ -87,7 +87,7 @@ class GuiStateMachineImplSpec extends AbstractApiSpec with BeforeAndAfterEach {
       s2.getNeverExploredActionTypesCounter shouldEqual 2
 
       // execute action1 for the second time but from s1SutState to create one incoming action from two different states
-      sut.executeAction(s1, action1, s2) shouldEqual 1
+      sut.executeAction(s1, action1, s2, true) shouldEqual 1
       s1.getOutgoingActionTransitions.size shouldEqual 1
       s1.getOutgoingActionTransitions(action1Identifier).states.size shouldEqual 1
       s1.getOutgoingActionTransitions(action1Identifier).executionCounter shouldEqual 1

--- a/src/test/scala/de/retest/guistatemachine/api/impl/GuiStateMachineImplSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/impl/GuiStateMachineImplSpec.scala
@@ -1,18 +1,11 @@
 package de.retest.guistatemachine.api.impl
 
-import de.retest.guistatemachine.api.{AbstractApiSpec, ActionIdentifier}
-import de.retest.surili.commons.actions.NavigateToAction
+import de.retest.guistatemachine.api.AbstractApiSpec
+import de.retest.surili.commons.actions.ActionType
 import org.scalatest.BeforeAndAfterEach
 
 class GuiStateMachineImplSpec extends AbstractApiSpec with BeforeAndAfterEach {
   private val sut = new GuiStateMachineImpl
-  private val rootElementA = getRootElement("a", 0)
-  private val rootElementB = getRootElement("b", 0)
-  private val rootElementC = getRootElement("c", 0)
-  private val action0 = new NavigateToAction("http://google.com")
-  private val action0Identifier = new ActionIdentifier(action0)
-  private val action1 = new NavigateToAction("http://wikipedia.org")
-  private val action1Identifier = new ActionIdentifier(action1)
 
   override def beforeEach() {
     sut.clear()
@@ -28,78 +21,78 @@ class GuiStateMachineImplSpec extends AbstractApiSpec with BeforeAndAfterEach {
       differentState.equals(s0) shouldBe false
       differentState.hashCode() should not equal s0.hashCode()
       sut.getAllStates.size shouldEqual 0
-      sut.createState(s0, 0)
+      sut.createState(s0, Set[ActionType]())
       sut.getAllStates.size shouldEqual 1
-      the[RuntimeException] thrownBy sut.createState(s0Equal, 0)
+      sut.createState(s0Equal, Set[ActionType]())
       sut.getAllStates.size shouldEqual 1
-      sut.createState(differentState, 0)
+      sut.createState(differentState, Set[ActionType]())
       sut.getAllStates.size shouldEqual 2
     }
 
     "add two transitions to two new states for the same action and two transitions for the same action to another state" in {
       val initialSutState = createSutState(rootElementA, rootElementB, rootElementC)
-      val initial = sut.createState(initialSutState, 2)
-      initial.getNeverExploredActionTypesCounter shouldEqual 2
+      val initial = sut.createState(initialSutState, unexploredActionTypes)
+      initial.getUnexploredActionTypes shouldEqual unexploredActionTypes
 
       // execute action0 for the first time
       val s0SutState = createSutState(rootElementA)
-      val s0 = sut.createState(s0SutState, 2)
-      sut.executeAction(initial, action0, s0, true) shouldEqual 1
+      val s0 = sut.createState(s0SutState, unexploredActionTypes)
+      sut.executeAction(initial, action0, s0) shouldEqual 1
       initial.getOutgoingActionTransitions.size shouldEqual 1
       initial.getOutgoingActionTransitions(action0Identifier).states.size shouldEqual 1
       initial.getOutgoingActionTransitions(action0Identifier).executionCounter shouldEqual 1
       initial.getIncomingActionTransitions.size shouldEqual 0
-      initial.getNeverExploredActionTypesCounter shouldEqual 1
+      initial.getUnexploredActionTypes shouldEqual unexploredActionTypes - actionType0
       s0.getOutgoingActionTransitions.size shouldEqual 0
       s0.getIncomingActionTransitions.size shouldEqual 1
       s0.getIncomingActionTransitions(action0Identifier).states.size shouldEqual 1
       s0.getIncomingActionTransitions(action0Identifier).executionCounter shouldEqual 1
-      s0.getNeverExploredActionTypesCounter shouldEqual 2
+      s0.getUnexploredActionTypes shouldEqual unexploredActionTypes
 
       // execute action0 for the second time
       val s1SutState = createSutState(rootElementB)
-      val s1 = sut.createState(s1SutState, 2)
-      sut.executeAction(initial, action0, s1, false) shouldEqual 2
+      val s1 = sut.createState(s1SutState, unexploredActionTypes)
+      sut.executeAction(initial, action0, s1) shouldEqual 2
       initial.getOutgoingActionTransitions.size shouldEqual 1
       initial.getOutgoingActionTransitions(action0Identifier).states.size shouldEqual 2
       initial.getOutgoingActionTransitions(action0Identifier).executionCounter shouldEqual 2
       initial.getIncomingActionTransitions.size shouldEqual 0
-      initial.getNeverExploredActionTypesCounter shouldEqual 1
+      initial.getUnexploredActionTypes shouldEqual unexploredActionTypes - actionType0
       s1.getOutgoingActionTransitions.size shouldEqual 0
       s1.getIncomingActionTransitions.size shouldEqual 1
       s1.getIncomingActionTransitions(action0Identifier).states.size shouldEqual 1
       s1.getIncomingActionTransitions(action0Identifier).executionCounter shouldEqual 1
-      s1.getNeverExploredActionTypesCounter shouldEqual 2
+      s1.getUnexploredActionTypes shouldEqual unexploredActionTypes
 
       // execute action1 for the first time
       val s2SutState = createSutState(rootElementC)
-      val s2 = sut.createState(s2SutState, 2)
-      sut.executeAction(initial, action1, s2, true) shouldEqual 1
+      val s2 = sut.createState(s2SutState, unexploredActionTypes)
+      sut.executeAction(initial, action1, s2) shouldEqual 1
       initial.getOutgoingActionTransitions.size shouldEqual 2
       initial.getOutgoingActionTransitions(action1Identifier).states.size shouldEqual 1
       initial.getOutgoingActionTransitions(action1Identifier).executionCounter shouldEqual 1
       initial.getIncomingActionTransitions.size shouldEqual 0
-      initial.getNeverExploredActionTypesCounter shouldEqual 0
+      initial.getUnexploredActionTypes shouldEqual Set()
       s2.getOutgoingActionTransitions.size shouldEqual 0
       s2.getIncomingActionTransitions.size shouldEqual 1
       s2.getIncomingActionTransitions(action1Identifier).states.size shouldEqual 1
       s2.getIncomingActionTransitions(action1Identifier).executionCounter shouldEqual 1
-      s2.getNeverExploredActionTypesCounter shouldEqual 2
+      s2.getUnexploredActionTypes shouldEqual unexploredActionTypes
 
       // execute action1 for the second time but from s1SutState to create one incoming action from two different states
-      sut.executeAction(s1, action1, s2, true) shouldEqual 1
+      sut.executeAction(s1, action1, s2) shouldEqual 1
       s1.getOutgoingActionTransitions.size shouldEqual 1
       s1.getOutgoingActionTransitions(action1Identifier).states.size shouldEqual 1
       s1.getOutgoingActionTransitions(action1Identifier).executionCounter shouldEqual 1
       s1.getIncomingActionTransitions.size shouldEqual 1
       s1.getIncomingActionTransitions(action0Identifier).states.size shouldEqual 1
       s1.getIncomingActionTransitions(action0Identifier).executionCounter shouldEqual 1
-      s1.getNeverExploredActionTypesCounter shouldEqual 1
+      s1.getUnexploredActionTypes shouldEqual unexploredActionTypes - actionType1
       s2.getOutgoingActionTransitions.size shouldEqual 0
       s2.getIncomingActionTransitions.size shouldEqual 1
       s2.getIncomingActionTransitions(action1Identifier).states shouldEqual Set(initial, s1)
       s2.getIncomingActionTransitions(action1Identifier).executionCounter shouldEqual 2
-      s2.getNeverExploredActionTypesCounter shouldEqual 2
+      s2.getUnexploredActionTypes shouldEqual unexploredActionTypes
     }
 
     "store a state for the second access" in {

--- a/src/test/scala/de/retest/guistatemachine/api/impl/StateImplSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/impl/StateImplSpec.scala
@@ -28,7 +28,7 @@ class StateImplSpec extends AbstractApiSpec {
 
     "be converted into a string" in {
       val s0 = StateImpl(sutStateAIdentifier, 2)
-      s0.toString shouldEqual "State[sutStateIdentifier=SutStateIdentifier[sutState=State[descriptor=[]], hash=0e4fd44f14d365fae3a7f3579b7ef013e1167e0f4ef6de418367b81edc63450d]]"
+      s0.toString shouldEqual "State[sutStateIdentifier=SutStateIdentifier[sutState=State[descriptor=[]], hash=0e4fd44f14d365fae3a7f3579b7ef013e1167e0f4ef6de418367b81edc63450d],neverExploredActionTypesCounter=2]"
     }
   }
 }

--- a/src/test/scala/de/retest/guistatemachine/api/impl/StateImplSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/impl/StateImplSpec.scala
@@ -12,22 +12,22 @@ class StateImplSpec extends AbstractApiSpec {
 
   "StateImpl" should {
     "not equal" in {
-      val s0 = StateImpl(sutStateAIdentifier)
-      val s1 = StateImpl(sutStateBIdentifier)
+      val s0 = StateImpl(sutStateAIdentifier, 1)
+      val s1 = StateImpl(sutStateBIdentifier, 1)
       s0.equals(s1) shouldEqual false
       s0.equals(10) shouldEqual false
       s0.hashCode() should not equal s1.hashCode()
     }
 
     "equal" in {
-      val s0 = StateImpl(sutStateAIdentifier)
-      val s1 = StateImpl(sutStateAIdentifier)
+      val s0 = StateImpl(sutStateAIdentifier, 1)
+      val s1 = StateImpl(sutStateAIdentifier, 2)
       s0.equals(s1) shouldEqual true
       s0.hashCode() shouldEqual s1.hashCode()
     }
 
     "be converted into a string" in {
-      val s0 = StateImpl(sutStateAIdentifier)
+      val s0 = StateImpl(sutStateAIdentifier, 2)
       s0.toString shouldEqual "State[sutStateIdentifier=SutStateIdentifier[sutState=State[descriptor=[]], hash=0e4fd44f14d365fae3a7f3579b7ef013e1167e0f4ef6de418367b81edc63450d]]"
     }
   }

--- a/src/test/scala/de/retest/guistatemachine/api/impl/StateImplSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/impl/StateImplSpec.scala
@@ -1,10 +1,9 @@
 package de.retest.guistatemachine.api.impl
 
 import de.retest.guistatemachine.api.{AbstractApiSpec, SutStateIdentifier}
+import de.retest.surili.commons.actions.ActionType
 
 class StateImplSpec extends AbstractApiSpec {
-  private val rootElementA = getRootElement("a", 0)
-  private val rootElementB = getRootElement("b", 0)
   private val sutStateA = createSutState(rootElementA)
   private val sutStateAIdentifier = new SutStateIdentifier(sutStateA)
   private val sutStateB = createSutState(rootElementB)
@@ -12,23 +11,23 @@ class StateImplSpec extends AbstractApiSpec {
 
   "StateImpl" should {
     "not equal" in {
-      val s0 = StateImpl(sutStateAIdentifier, 1)
-      val s1 = StateImpl(sutStateBIdentifier, 1)
+      val s0 = StateImpl(sutStateAIdentifier, Set(ActionType.fromAction(action0)))
+      val s1 = StateImpl(sutStateBIdentifier, Set(ActionType.fromAction(action0)))
       s0.equals(s1) shouldEqual false
       s0.equals(10) shouldEqual false
       s0.hashCode() should not equal s1.hashCode()
     }
 
     "equal" in {
-      val s0 = StateImpl(sutStateAIdentifier, 1)
-      val s1 = StateImpl(sutStateAIdentifier, 2)
+      val s0 = StateImpl(sutStateAIdentifier, Set(ActionType.fromAction(action0)))
+      val s1 = StateImpl(sutStateAIdentifier, Set(ActionType.fromAction(action0), ActionType.fromAction(action1)))
       s0.equals(s1) shouldEqual true
       s0.hashCode() shouldEqual s1.hashCode()
     }
 
     "be converted into a string" in {
-      val s0 = StateImpl(sutStateAIdentifier, 2)
-      s0.toString shouldEqual "State[sutStateIdentifier=SutStateIdentifier[sutState=State[descriptor=[]], hash=0e4fd44f14d365fae3a7f3579b7ef013e1167e0f4ef6de418367b81edc63450d],neverExploredActionTypesCounter=2]"
+      val s0 = StateImpl(sutStateAIdentifier, unexploredActionTypes)
+      s0.toString shouldEqual "State[sutStateIdentifier=SutStateIdentifier[sutState=State[descriptor=[]], hash=0e4fd44f14d365fae3a7f3579b7ef013e1167e0f4ef6de418367b81edc63450d],unexploredActionTypes=Set(ActionType(elementPath=, type=de.retest.surili.commons.actions.NavigateToAction))]"
     }
   }
 }

--- a/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineGMLSerializerSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineGMLSerializerSpec.scala
@@ -28,10 +28,10 @@ class GuiStateMachineGMLSerializerSpec extends AbstractApiSpec with BeforeAndAft
       // Create the whole state machine:
       val initialState = guiStateMachine.createState(initialSutState, 2)
       val finalState = guiStateMachine.createState(finalSutState, 2)
-      guiStateMachine.executeAction(initialState, action0, finalState)
-      guiStateMachine.executeAction(initialState, action1, finalState)
-      guiStateMachine.executeAction(finalState, action0, initialState)
-      guiStateMachine.executeAction(finalState, action1, initialState)
+      guiStateMachine.executeAction(initialState, action0, finalState, true)
+      guiStateMachine.executeAction(initialState, action1, finalState, true)
+      guiStateMachine.executeAction(finalState, action0, initialState, true)
+      guiStateMachine.executeAction(finalState, action1, initialState, true)
 
       val filePath = "./target/test_state_machine.gml"
       val oldFile = new File(filePath)

--- a/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineGMLSerializerSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineGMLSerializerSpec.scala
@@ -4,7 +4,6 @@ import java.io.File
 
 import de.retest.guistatemachine.api.impl.GuiStateMachineImpl
 import de.retest.guistatemachine.api.{AbstractApiSpec, GuiStateMachineSerializer}
-import de.retest.surili.commons.actions.NavigateToAction
 import org.scalatest.BeforeAndAfterEach
 
 class GuiStateMachineGMLSerializerSpec extends AbstractApiSpec with BeforeAndAfterEach {
@@ -16,22 +15,16 @@ class GuiStateMachineGMLSerializerSpec extends AbstractApiSpec with BeforeAndAft
 
   "GuiStateMachineGMLSerializer" should {
     "save GML " in {
-      val rootElementA = getRootElement("a", 0)
-      val rootElementB = getRootElement("b", 0)
-      val rootElementC = getRootElement("c", 0)
-      val action0 = new NavigateToAction("http://google.com")
-      val action1 = new NavigateToAction("http://wikipedia.org")
-
       val initialSutState = createSutState(rootElementA, rootElementB, rootElementC)
       val finalSutState = createSutState(rootElementC)
 
       // Create the whole state machine:
-      val initialState = guiStateMachine.createState(initialSutState, 2)
-      val finalState = guiStateMachine.createState(finalSutState, 2)
-      guiStateMachine.executeAction(initialState, action0, finalState, true)
-      guiStateMachine.executeAction(initialState, action1, finalState, true)
-      guiStateMachine.executeAction(finalState, action0, initialState, true)
-      guiStateMachine.executeAction(finalState, action1, initialState, true)
+      val initialState = guiStateMachine.createState(initialSutState, unexploredActionTypes)
+      val finalState = guiStateMachine.createState(finalSutState, unexploredActionTypes)
+      guiStateMachine.executeAction(initialState, action0, finalState)
+      guiStateMachine.executeAction(initialState, action1, finalState)
+      guiStateMachine.executeAction(finalState, action0, initialState)
+      guiStateMachine.executeAction(finalState, action1, initialState)
 
       val filePath = "./target/test_state_machine.gml"
       val oldFile = new File(filePath)

--- a/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineGMLSerializerSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineGMLSerializerSpec.scala
@@ -26,10 +26,12 @@ class GuiStateMachineGMLSerializerSpec extends AbstractApiSpec with BeforeAndAft
       val finalSutState = createSutState(rootElementC)
 
       // Create the whole state machine:
-      guiStateMachine.executeAction(initialSutState, action0, finalSutState)
-      guiStateMachine.executeAction(initialSutState, action1, finalSutState)
-      guiStateMachine.executeAction(finalSutState, action0, initialSutState)
-      guiStateMachine.executeAction(finalSutState, action1, initialSutState)
+      val initialState = guiStateMachine.createState(initialSutState, 2)
+      val finalState = guiStateMachine.createState(finalSutState, 2)
+      guiStateMachine.executeAction(initialState, action0, finalState)
+      guiStateMachine.executeAction(initialState, action1, finalState)
+      guiStateMachine.executeAction(finalState, action0, initialState)
+      guiStateMachine.executeAction(finalState, action1, initialState)
 
       val filePath = "./target/test_state_machine.gml"
       val oldFile = new File(filePath)
@@ -160,7 +162,9 @@ class GuiStateMachineGMLSerializerSpec extends AbstractApiSpec with BeforeAndAft
     }
 
     "load GML " in {
-      the[UnsupportedOperationException] thrownBy GuiStateMachineSerializer.gml(guiStateMachine).load("bla") should have message "Loading GML is not supported."
+      the[UnsupportedOperationException] thrownBy GuiStateMachineSerializer
+        .gml(guiStateMachine)
+        .load("bla") should have message "Loading GML is not supported."
     }
   }
 }

--- a/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineJavaObjectStreamSerializerSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineJavaObjectStreamSerializerSpec.scala
@@ -35,7 +35,9 @@ class GuiStateMachineJavaObjectStreamSerializerSpec extends AbstractApiSpec with
       val finalSutStateIdentifier = new SutStateIdentifier(finalSutState)
 
       // Create the whole state machine:
-      guiStateMachine.executeAction(initialSutState, action0, finalSutState)
+      val initialState = guiStateMachine.createState(initialSutStateIdentifier, 1)
+      val finalState = guiStateMachine.createState(finalSutStateIdentifier, 1)
+      guiStateMachine.executeAction(initialState, action0, finalState)
 
       // Save the state machine:
       GuiStateMachineSerializer.javaObjectStream(guiStateMachine).save(filePath)

--- a/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineJavaObjectStreamSerializerSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineJavaObjectStreamSerializerSpec.scala
@@ -3,8 +3,7 @@ package de.retest.guistatemachine.api.impl.serialization
 import java.io.File
 
 import de.retest.guistatemachine.api.impl.GuiStateMachineImpl
-import de.retest.guistatemachine.api.{AbstractApiSpec, ActionIdentifier, GuiStateMachineSerializer, SutStateIdentifier}
-import de.retest.surili.commons.actions.NavigateToAction
+import de.retest.guistatemachine.api.{AbstractApiSpec, GuiStateMachineSerializer, SutStateIdentifier}
 import org.scalatest.BeforeAndAfterEach
 
 class GuiStateMachineJavaObjectStreamSerializerSpec extends AbstractApiSpec with BeforeAndAfterEach {

--- a/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineJavaObjectStreamSerializerSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineJavaObjectStreamSerializerSpec.scala
@@ -21,23 +21,15 @@ class GuiStateMachineJavaObjectStreamSerializerSpec extends AbstractApiSpec with
 
       if (oldFile.exists()) { oldFile.delete() } shouldEqual true
 
-      val rootElementA = getRootElement("a", 0)
-      val rootElementB = getRootElement("b", 0)
-      val rootElementC = getRootElement("c", 0)
-      val action0 = new NavigateToAction("http://google.com")
-      val action0Identifier = new ActionIdentifier(action0)
-      val action1 = new NavigateToAction("http://wikipedia.org")
-      val action1Identifier = new ActionIdentifier(action1)
-
       val initialSutState = createSutState(rootElementA, rootElementB, rootElementC)
       val initialSutStateIdentifier = new SutStateIdentifier(initialSutState)
       val finalSutState = createSutState(rootElementC)
       val finalSutStateIdentifier = new SutStateIdentifier(finalSutState)
 
       // Create the whole state machine:
-      val initialState = guiStateMachine.createState(initialSutStateIdentifier, 1)
-      val finalState = guiStateMachine.createState(finalSutStateIdentifier, 1)
-      guiStateMachine.executeAction(initialState, action0, finalState, true)
+      val initialState = guiStateMachine.createState(initialSutStateIdentifier, unexploredActionTypes)
+      val finalState = guiStateMachine.createState(finalSutStateIdentifier, unexploredActionTypes)
+      guiStateMachine.executeAction(initialState, action0, finalState)
 
       // Save the state machine:
       GuiStateMachineSerializer.javaObjectStream(guiStateMachine).save(filePath)
@@ -56,12 +48,14 @@ class GuiStateMachineJavaObjectStreamSerializerSpec extends AbstractApiSpec with
       loadedInitialState.getSutStateIdentifier shouldEqual initialSutStateIdentifier
       loadedInitialState.getOutgoingActionTransitions.size shouldEqual 1
       loadedInitialState.getOutgoingActionTransitions.contains(action0Identifier) shouldEqual true
+      loadedInitialState.getUnexploredActionTypes shouldEqual unexploredActionTypes - actionType0
       val loadedTransition = loadedInitialState.getOutgoingActionTransitions(action0Identifier)
       loadedTransition.executionCounter shouldEqual 1
       loadedTransition.states.size shouldEqual 1
       loadedTransition.states.head shouldEqual loadedFinalState
       loadedFinalState.getSutStateIdentifier shouldEqual finalSutStateIdentifier
       loadedFinalState.getOutgoingActionTransitions.isEmpty shouldEqual true
+      loadedInitialState.getUnexploredActionTypes shouldEqual unexploredActionTypes
     }
   }
 }

--- a/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineJavaObjectStreamSerializerSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineJavaObjectStreamSerializerSpec.scala
@@ -37,7 +37,7 @@ class GuiStateMachineJavaObjectStreamSerializerSpec extends AbstractApiSpec with
       // Create the whole state machine:
       val initialState = guiStateMachine.createState(initialSutStateIdentifier, 1)
       val finalState = guiStateMachine.createState(finalSutStateIdentifier, 1)
-      guiStateMachine.executeAction(initialState, action0, finalState)
+      guiStateMachine.executeAction(initialState, action0, finalState, true)
 
       // Save the state machine:
       GuiStateMachineSerializer.javaObjectStream(guiStateMachine).save(filePath)

--- a/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineJavaObjectStreamSerializerSpec.scala
+++ b/src/test/scala/de/retest/guistatemachine/api/impl/serialization/GuiStateMachineJavaObjectStreamSerializerSpec.scala
@@ -55,7 +55,7 @@ class GuiStateMachineJavaObjectStreamSerializerSpec extends AbstractApiSpec with
       loadedTransition.states.head shouldEqual loadedFinalState
       loadedFinalState.getSutStateIdentifier shouldEqual finalSutStateIdentifier
       loadedFinalState.getOutgoingActionTransitions.isEmpty shouldEqual true
-      loadedInitialState.getUnexploredActionTypes shouldEqual unexploredActionTypes
+      loadedFinalState.getUnexploredActionTypes shouldEqual unexploredActionTypes
     }
   }
 }


### PR DESCRIPTION
Store a counter for unexplored actions which is set when creating a state.
The alternative to the unexplored action flag is that this artefact knows the type `ActionType` from Surili which is not deployed yet.